### PR TITLE
Fix Next Joke loading button

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -108,19 +108,19 @@ function displayJoke(jokeText, addToHistory = true) {
  */
 function setLoadingState(loading) {
     isLoading = loading;
-    const buttons = ['next-btn', 'search-btn'];
+    const buttons = ['random-btn', 'search-btn'];
     
     buttons.forEach(btnId => {
         const btn = document.getElementById(btnId);
         if (!btn) return;
-        
-        if (btnId === 'next-btn') {
-            // Disable next button when loading
+
+        if (btnId === 'random-btn') {
+            // Disable next joke button when loading
             btn.disabled = loading;
             if (loading) {
                 btn.innerHTML = '<div class="loading"><div class="spinner"></div>Loading...</div>';
             } else {
-                btn.innerHTML = 'Next →';
+                btn.innerHTML = 'Next Joke';
             }
         } else if (btnId === 'search-btn') {
             btn.disabled = loading;


### PR DESCRIPTION
## Summary
- fix loading spinner target in `setLoadingState`

## Testing
- `node --check js/main.js`
- `node --check js/favoritesManager.js`
- `node --check js/historyManager.js`
- `node --check js/jokeService.js`
- `node --check js/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_6849987694548326be6a550e2385eb1a