### PR TITLE
Add Jest and unit tests for splitJoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "learnfunnyjokes",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadUtils() {
+  const filePath = path.resolve(__dirname, '../js/utils.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return context;
+}
+
+describe('splitJoke', () => {
+  const { splitJoke } = loadUtils();
+
+  test('joke with setup and punchline', () => {
+    const result = splitJoke('Why did the chicken cross the road? To get to the other side!');
+    expect(result).toEqual({
+      setup: 'Why did the chicken cross the road?',
+      punchline: 'To get to the other side!'
+    });
+  });
+
+  test('joke with no punchline', () => {
+    const result = splitJoke('I would tell you a UDP joke but you might not get it');
+    expect(result).toEqual({
+      setup: 'I would tell you a UDP joke but you might not get it',
+      punchline: ''
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency
- add npm test script
- ignore node_modules and lockfile
- test `splitJoke` for normal and single-line jokes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849a3942cd88326aa395dc5f12ffe26