### PR TITLE
fix: clear invalid favorites from storage

### DIFF
--- a/js/favoritesManager.js
+++ b/js/favoritesManager.js
@@ -20,6 +20,8 @@ class FavoritesManager {
             this.updateFavoritesCount();
         } catch (error) {
             console.error('Error loading favorites:', error);
+            // Clear potentially corrupt stored data
+            localStorage.removeItem(this.storageKey);
             this.favorites = [];
         }
     }


### PR DESCRIPTION
## Summary
- prevent reloading corrupted favorites by clearing localStorage when JSON parse fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a3836dcc8326acac3b8e9ffcc363