### PR TITLE
Add share button and improve joke card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,14 @@
                     Why don't scientists trust atoms?<br>
                     <span class="punchline">Because they make up everything!</span>
                 </div>
-                <div class="joke-actions">
-                    <button class="favorite-btn" onclick="toggleFavorite()" id="favorite-btn" title="Add to favorites">♡</button>
-                    <button class="copy-btn" onclick="copyJoke()" id="copy-btn">Copy Joke</button>
+                <div class="joke-footer">
+                    <div class="joke-actions">
+                        <button class="favorite-btn" onclick="toggleFavorite()" id="favorite-btn" title="Add to favorites">♡</button>
+                        <button class="copy-btn" onclick="copyJoke()" id="copy-btn">Copy Joke</button>
+                        <button class="share-btn" onclick="shareJoke()" id="share-btn">Share</button>
+                    </div>
+                    <div class="confirmation-message" id="confirmation-message">Copied!</div>
                 </div>
-                <div class="confirmation-message" id="confirmation-message">Copied!</div>
             </div>
         </div>
         
@@ -306,6 +309,25 @@
                     console.error('Fallback copy also failed:', fallbackError);
                     showError('Failed to copy joke. Your browser may not support this feature.');
                 }
+            }
+        }
+
+        // Function to share the current joke using the Web Share API
+        async function shareJoke() {
+            try {
+                const jokeElement = document.getElementById('joke-text');
+                const jokeText = jokeElement.textContent || jokeElement.innerText;
+
+                if (navigator.share) {
+                    await navigator.share({ text: jokeText });
+                    showConfirmation('Shared!');
+                } else {
+                    await navigator.clipboard.writeText(jokeText);
+                    showConfirmation('Copied!');
+                }
+            } catch (error) {
+                console.error('Failed to share joke:', error);
+                showError('Share not supported on this browser.');
             }
         }
 

--- a/styles.css
+++ b/styles.css
@@ -48,9 +48,10 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     transition: all 0.3s ease;
+    position: relative;
 }
 
 .joke-container:hover {
@@ -85,6 +86,18 @@ h1 {
     font-weight: bold;
     margin-top: 12px;
     display: block;
+}
+
+.joke-footer {
+    margin-top: auto;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.joke-text {
+    flex: 1;
 }
 
 .controls {
@@ -338,8 +351,15 @@ h1 {
         min-width: 56px;
         min-height: 56px;
     }
-    
+
     .copy-btn {
+        padding: 16px 24px;
+        font-size: 1rem;
+        min-height: 52px;
+        min-width: 140px;
+    }
+
+    .share-btn {
         padding: 16px 24px;
         font-size: 1rem;
         min-height: 52px;
@@ -408,6 +428,13 @@ h1 {
     }
     
     .copy-btn {
+        padding: 14px 20px;
+        font-size: 0.95rem;
+        min-height: 48px;
+        min-width: 120px;
+    }
+
+    .share-btn {
         padding: 14px 20px;
         font-size: 0.95rem;
         min-height: 48px;
@@ -485,7 +512,39 @@ h1 {
     appearance: none;
 }
 
+.share-btn {
+    background: linear-gradient(45deg, #007bff, #0069d9);
+    color: white;
+    border: none;
+    padding: 14px 20px;
+    font-size: 0.95rem;
+    border-radius: 22px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    font-weight: bold;
+    margin-top: 0;
+    min-width: 120px;
+    min-height: 48px;
+    position: relative;
+    overflow: hidden;
+    touch-action: manipulation;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+
 .copy-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+    transition: left 0.5s;
+}
+
+.share-btn::before {
     content: '';
     position: absolute;
     top: 0;
@@ -501,7 +560,16 @@ h1 {
     box-shadow: 0 6px 20px rgba(108, 117, 125, 0.4);
 }
 
+.share-btn:hover {
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 6px 20px rgba(0, 123, 255, 0.4);
+}
+
 .copy-btn:hover::before {
+    left: 100%;
+}
+
+.share-btn:hover::before {
     left: 100%;
 }
 
@@ -510,7 +578,18 @@ h1 {
     transition: all 0.1s;
 }
 
+.share-btn:active {
+    transform: translateY(0) scale(0.95);
+    transition: all 0.1s;
+}
+
 .copy-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.share-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
     transform: none;


### PR DESCRIPTION
## Summary
- move joke action buttons into a footer at the bottom of the joke card
- add a new **Share** button and Web Share API support
- style the share button and update layout styles so actions sit at the bottom

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684af0a68ed48326b293435ca98a84d5