### PR TITLE
Fix Next Joke button resizing on click

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -181,6 +181,17 @@ h1 {
     transition: all 0.1s;
 }
 
+/* Keep the Next Joke button static when pressed */
+#random-btn:hover,
+#random-btn:active {
+    transform: none;
+    transition: none;
+}
+
+#random-btn {
+    height: 52px;
+}
+
 .btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;


### PR DESCRIPTION
## Summary
- prevent active/hover scaling on Next Joke button
- keep Next Joke button at a fixed height to avoid layout shift

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c3eeeb883269914a204d3289216