### PR TITLE
Change Copy button to show temporary "Copied" text

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,29 +267,43 @@
                 // Get the current joke text (without HTML tags)
                 const jokeElement = document.getElementById('joke-text');
                 const jokeText = jokeElement.textContent || jokeElement.innerText;
-                
+
                 // Copy to clipboard using the modern Clipboard API
                 await navigator.clipboard.writeText(jokeText);
-                
-                // Show confirmation message
-                showConfirmation();
-                
+
+                // Temporarily change button text
+                const btn = document.getElementById('copy-btn');
+                if (btn) {
+                    const original = btn.textContent;
+                    btn.textContent = 'Copied';
+                    setTimeout(() => {
+                        btn.textContent = original;
+                    }, 2000);
+                }
+
             } catch (error) {
                 console.error('Failed to copy joke:', error);
-                
+
                 // Fallback for older browsers or if clipboard access fails
                 try {
                     const textArea = document.createElement('textarea');
                     const jokeElement = document.getElementById('joke-text');
                     const jokeText = jokeElement.textContent || jokeElement.innerText;
-                    
+
                     textArea.value = jokeText;
                     document.body.appendChild(textArea);
                     textArea.select();
                     document.execCommand('copy');
                     document.body.removeChild(textArea);
-                    
-                    showConfirmation();
+
+                    const btn = document.getElementById('copy-btn');
+                    if (btn) {
+                        const original = btn.textContent;
+                        btn.textContent = 'Copied';
+                        setTimeout(() => {
+                            btn.textContent = original;
+                        }, 2000);
+                    }
                 } catch (fallbackError) {
                     console.error('Fallback copy also failed:', fallbackError);
                     showError('Failed to copy joke. Your browser may not support this feature.');

--- a/js/main.js
+++ b/js/main.js
@@ -181,7 +181,14 @@ async function copyJoke() {
     try {
         const success = await copyToClipboard(jokeText);
         if (success) {
-            showConfirmation('Copied!');
+            const btn = document.getElementById('copy-btn');
+            if (btn) {
+                const original = btn.textContent;
+                btn.textContent = 'Copied';
+                setTimeout(() => {
+                    btn.textContent = original;
+                }, 2000);
+            }
         } else {
             showError('Failed to copy joke. Your browser may not support this feature.');
         }


### PR DESCRIPTION
## Summary
- update copyJoke in inline script to swap button text when copying
- do the same in main.js for parity

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b63bcfd648326b84b34a17b48ea39