### PR TITLE
Move joke card footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -42,7 +42,7 @@ h1 {
 .joke-container {
     background: #f8f9fa;
     border-radius: 10px;
-    padding: 25px 20px 80px;
+    padding: 25px 20px;
     margin: 25px 0;
     min-height: 160px;
     display: flex;
@@ -89,10 +89,7 @@ h1 {
 }
 
 .joke-footer {
-    position: absolute;
-    bottom: 15px;
-    left: 0;
-    right: 0;
+    margin-top: 20px;
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -592,7 +589,7 @@ h1 {
     justify-content: center;
     align-items: center;
     gap: 20px;
-    margin-top: 20px;
+    margin-top: 0;
     flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## Summary
- remove large padding from `.joke-container`
- make footer part of the normal flow instead of absolutely positioned
- keep copy/share buttons grouped with no extra margin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b6543b6e483268d24568d7f36c0c9