### PR TITLE
Fix horizontal overflow on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
 * {
+    box-sizing: border-box;
     -webkit-tap-highlight-color: transparent;
     -webkit-touch-callout: none;
     -webkit-user-select: none;


### PR DESCRIPTION
## Summary
- set `box-sizing: border-box` globally to prevent layout overflow on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8074a3388326b2799e55d8f4ddff