### PR TITLE
Fix infinite scroll support on older iOS

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -281,12 +281,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const sentinel = document.getElementById('jokes-sentinel');
     if (sentinel) {
-        const observer = new IntersectionObserver(entries => {
-            if (entries[0].isIntersecting) {
-                loadMoreJokes(1);
-            }
-        }, { rootMargin: '200px' });
-        observer.observe(sentinel);
+        if ('IntersectionObserver' in window) {
+            const observer = new IntersectionObserver(entries => {
+                if (entries[0].isIntersecting) {
+                    loadMoreJokes(1);
+                }
+            }, { rootMargin: '200px' });
+            observer.observe(sentinel);
+        } else {
+            // Fallback for older browsers without IntersectionObserver
+            const onScroll = () => {
+                const rect = sentinel.getBoundingClientRect();
+                if (rect.top - window.innerHeight < 200) {
+                    loadMoreJokes(1);
+                }
+            };
+            window.addEventListener('scroll', onScroll, { passive: true });
+        }
     }
 
     const searchInput = document.getElementById('search-input');

--- a/styles.css
+++ b/styles.css
@@ -668,5 +668,6 @@ h1 {
 
 #jokes-sentinel {
     height: 1px;
+    width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- support browsers without IntersectionObserver by falling back to a scroll handler
- make sentinel span full width so it can be detected reliably

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ccb00dc948326b7f791d1ccec992d