### PR TITLE
Load more jokes initially

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -277,7 +277,7 @@ async function loadMoreJokes(count = 1) {
 // Add event listeners for keyboard support
 document.addEventListener('DOMContentLoaded', function() {
     // Load initial jokes
-    loadMoreJokes(3);
+    loadMoreJokes(5);
 
     const sentinel = document.getElementById('jokes-sentinel');
     if (sentinel) {


### PR DESCRIPTION
## Summary
- load 5 jokes when the page first loads instead of 3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce13f5ecc8326a1f7814705e7b056