### PR TITLE
Add colorful backgrounds to joke cards

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -122,6 +122,9 @@ function displayJoke(jokeText) {
 
     const card = document.createElement('div');
     card.className = 'joke-container fade-in';
+    const lightBackgrounds = ['#fffbe6', '#e6f7ff', '#fff0f6'];
+    const randomBg = lightBackgrounds[Math.floor(Math.random() * lightBackgrounds.length)];
+    card.style.background = randomBg;
 
     // Split into setup and punchline
     const questionMarkers = ['?', '!'];

--- a/styles.css
+++ b/styles.css
@@ -76,8 +76,8 @@ h1 {
 }
 
 .joke-container {
-    background: #f8f9fa;
-    border-radius: 10px;
+    background: #fffbe6;
+    border-radius: 12px;
     padding: 25px 20px;
     margin: 25px 0;
     width: 100%;
@@ -86,9 +86,10 @@ h1 {
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
     transition: all 0.3s ease;
     position: relative;
+    color: #333;
 }
 
 .joke-container:hover {


### PR DESCRIPTION
## Summary
- lighten the `.joke-container` style and ensure dark text
- randomly choose a light background color for each joke card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce21d949c83268b3f1948baf40e0a