### PR TITLE
Remove hover effect on joke cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -93,10 +93,6 @@ h1 {
     color: #1a1a1a;
 }
 
-.joke-container:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
-}
 
 .joke-text {
     font-size: 1.4rem;


### PR DESCRIPTION
## Summary
- remove `.joke-container:hover` style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ce93768d8832698d99c4469db7843