### PR TITLE
Fix Enter key search on search page

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -311,7 +311,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Enter key in search input triggers search
     if (searchInput) {
-        searchInput.addEventListener('keypress', function(event) {
+        searchInput.addEventListener('keydown', function(event) {
             if (event.key === 'Enter') {
                 searchJokes();
             }
@@ -319,7 +319,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     
     // Global Enter key listener for getting next joke (when not in search input)
-    document.addEventListener('keypress', function(event) {
+    document.addEventListener('keydown', function(event) {
         if (event.key === 'Enter' && document.activeElement !== searchInput) {
             getRandomJoke();
         }

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ function setupEventListeners() {
     
     // Enter key in search input triggers search
     if (searchInput) {
-        searchInput.addEventListener('keypress', function(event) {
+        searchInput.addEventListener('keydown', function(event) {
             if (event.key === 'Enter') {
                 searchJokes();
             }


### PR DESCRIPTION
## Summary
- handle Enter presses using `keydown` instead of deprecated `keypress`
- update search page logic so pressing Enter triggers search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ce9d9d1c08326992e5ecf2b9c087b