### PR TITLE
Add SVG icons for header buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,12 @@
     <div class="container">
         <header class="site-header">
             <h1>Learn Funny Jokes</h1>
-            <a href="search.html" class="header-search" aria-label="Search">🔍</a>
+            <a href="search.html" class="header-search icon-button" aria-label="Search">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="8"></circle>
+                    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                </svg>
+            </a>
         </header>
         
         <!-- Removed favorites toggle -->

--- a/search.html
+++ b/search.html
@@ -10,7 +10,11 @@
 <body>
     <div class="container">
         <header class="site-header">
-            <a href="index.html" class="header-back" aria-label="Back">⬅️</a>
+            <a href="index.html" class="header-back icon-button" aria-label="Back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+            </a>
             <h1>Search Jokes</h1>
         </header>
         <div class="search-container">

--- a/styles.css
+++ b/styles.css
@@ -63,30 +63,32 @@ h1 {
     text-align: left;
 }
 
-.header-search {
+.icon-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid rgba(0, 0, 0, 0.9);
+    background: transparent;
+    color: rgba(0, 0, 0, 0.9);
     text-decoration: none;
-    font-size: 1.2rem;
-    padding: 6px;
-    border-radius: 6px;
-    background: #28a745;
-    color: white;
 }
 
+.icon-button svg {
+    width: 20px;
+    height: 20px;
+    stroke: currentColor;
+}
+
+.icon-button:hover {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.header-search,
 .header-back {
     text-decoration: none;
-    font-size: 1.2rem;
-    padding: 6px;
-    border-radius: 6px;
-    background: #007bff;
-    color: white;
-}
-
-.header-search:hover {
-    background: #20c997;
-}
-
-.header-back:hover {
-    background: #0056b3;
 }
 
 .joke-container {


### PR DESCRIPTION
## Summary
- replace emoji buttons with inline SVG icons
- style header buttons as circular icon buttons with subtle black stroke

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ceab385c08326869b34487ca7a506