### PR TITLE
Add subtle border around joke cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,7 @@ h1 {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
     transition: all 0.3s ease;
     position: relative;
+    border: 2px solid rgba(0, 0, 0, 0.2);
     color: #1a1a1a;
 }
 


### PR DESCRIPTION
## Summary
- add a semi-transparent black border on joke cards for better separation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ced561f6083268fc9372f8a38321f