### PR TITLE
Fix search header alignment

### DIFF
--- a/search.html
+++ b/search.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <div class="container">
-        <header class="site-header">
+        <header class="site-header search-header">
             <a href="index.html" class="header-back icon-button" aria-label="Back">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <polyline points="15 18 9 12 15 6"></polyline>

--- a/styles.css
+++ b/styles.css
@@ -58,6 +58,11 @@ h1 {
     padding: 10px 0;
 }
 
+.site-header.search-header {
+    justify-content: flex-start;
+    gap: 16px;
+}
+
 .site-header h1 {
     margin: 0;
     text-align: left;


### PR DESCRIPTION
## Summary
- align search page header left
- add 16px spacing between the back button and "Search Jokes"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cedb799048326a30f5c7bf8f97075