### PR TITLE
Set copy/share button to primary style

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -157,12 +157,12 @@ function displayJoke(jokeText) {
     actions.className = 'joke-actions';
 
     const copyButton = document.createElement('button');
-    copyButton.className = 'copy-btn';
+    copyButton.className = 'copy-btn btn-primary';
     copyButton.textContent = 'Copy';
     copyButton.addEventListener('click', () => copyJoke(jokeText, copyButton));
 
     const shareButton = document.createElement('button');
-    shareButton.className = 'share-btn';
+    shareButton.className = 'share-btn btn-primary';
     shareButton.textContent = 'Share';
     shareButton.addEventListener('click', () => shareJoke(jokeText));
 

--- a/styles.css
+++ b/styles.css
@@ -261,6 +261,13 @@ h1 {
     box-shadow: 0 8px 25px rgba(40, 167, 69, 0.4);
 }
 
+/* Primary button style used for copy and share actions */
+.btn-primary {
+    background: #333333;
+    color: #ffffff;
+    border: none;
+}
+
 .loading {
     display: flex;
     align-items: center;
@@ -526,9 +533,6 @@ h1 {
 }
 
 .copy-btn {
-    background: #1a1a1a;
-    color: white;
-    border: none;
     padding: 10px 16px;
     font-size: 0.9rem;
     border-radius: 20px;
@@ -547,9 +551,7 @@ h1 {
 }
 
 .share-btn {
-    background: #1a1a1a;
-    color: white;
-    border: none;
+    
     padding: 10px 16px;
     font-size: 0.9rem;
     border-radius: 20px;


### PR DESCRIPTION
## Summary
- style copy/share buttons with 80% black via new `.btn-primary`
- add `btn-primary` class to buttons in feed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cee882c508326bda4bdac7b129b86