### PR TITLE
Adjust button color to 60% black

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -545,7 +545,7 @@ h1 {
 }
 
 .copy-btn {
-    background: rgba(0, 0, 0, 0.8);
+    background: #00000099;
     color: white;
     border: none;
     padding: 10px 16px;
@@ -566,7 +566,7 @@ h1 {
 }
 
 .share-btn {
-    background: rgba(0, 0, 0, 0.8);
+    background: #00000099;
     color: white;
     border: none;
     padding: 10px 16px;
@@ -722,7 +722,7 @@ h1 {
 
 /* Primary button style used for Copy and Share buttons */
 .btn-primary {
-    background: rgba(0, 0, 0, 0.8);
+    background: #00000099;
     color: #ffffff;
     border: none;
 }


### PR DESCRIPTION
## Summary
- switch copy and share buttons to 60% black via hex code
- update `.btn-primary` to use the same value

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf7eda7608326aafe2f393af84161