### PR TITLE
Add horizontal search results with infinite scroll

### DIFF
--- a/search.html
+++ b/search.html
@@ -20,7 +20,9 @@
         <div class="search-container">
             <input type="text" id="search-input" class="search-input" placeholder="Search">
         </div>
-        <div class="jokes-feed" id="jokes-feed"></div>
+        <div class="jokes-feed search-results" id="jokes-feed">
+            <div id="jokes-sentinel"></div>
+        </div>
     </div>
     <script src="js/feed.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -720,6 +720,23 @@ h1 {
     width: 100%;
 }
 
+/* Horizontal scrolling for search results */
+.search-results {
+    flex-direction: row;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+}
+
+.search-results .joke-container {
+    flex: 0 0 80%;
+    scroll-snap-align: start;
+}
+
+.search-results #jokes-sentinel {
+    width: 1px;
+    height: 100%;
+}
+
 /* Primary button style used for Copy and Share buttons */
 .btn-primary {
     background: #000000cc;


### PR DESCRIPTION
## Summary
- enable horizontal scrolling layout for search results
- add sentinel to search page and style for horizontal layout
- fetch five jokes per search and load more when scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7eeedd2483268e39ec609220d373