### PR TITLE
Fix vertical scrolling on search page

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -334,7 +334,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 observer.observe(sentinel);
             } else {
                 const onScroll = () => {
-                    if (feed.scrollWidth - feed.scrollLeft - feed.clientWidth < 50 && currentSearchTerm) {
+                    if (feed.scrollHeight - feed.scrollTop - feed.clientHeight < 50 && currentSearchTerm) {
                         searchJokes(false);
                     }
                 };

--- a/styles.css
+++ b/styles.css
@@ -719,21 +719,20 @@ h1 {
     width: 100%;
 }
 
-/* Horizontal scrolling for search results */
+/* Vertical scrolling for search results */
 .search-results {
-    flex-direction: row;
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
+    flex-direction: column;
+    overflow-y: auto;
 }
 
 .search-results .joke-container {
-    flex: 0 0 80%;
-    scroll-snap-align: start;
+    flex: 1 0 auto;
+    scroll-snap-align: unset;
 }
 
 .search-results #jokes-sentinel {
-    width: 1px;
-    height: 100%;
+    width: 100%;
+    height: 1px;
 }
 
 /* Primary button style used for Copy and Share buttons */


### PR DESCRIPTION
## Summary
- remove horizontal scroll rules from `.search-results`
- adjust fallback infinite scroll logic for vertical scrolling

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d813157688326a56ba3ed52beed40