### PR TITLE
Ensure site background matches container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,10 @@
     user-select: none;
 }
 
+html {
+    background: #fffbe6;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     max-width: 600px;
@@ -24,9 +28,11 @@ body {
 
 .container {
     background: transparent;
+    background-color: transparent;
     border-radius: 15px;
     padding: 25px 20px;
     box-shadow: none;
+    border: none;
     text-align: center;
     width: 100%;
     max-width: 500px;


### PR DESCRIPTION
## Summary
- add an `html` background color so the beige backdrop fills the full viewport and no white outer area shows
- explicitly keep the main container transparent and borderless to guarantee the white background is removed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e01abd534832695e0927a5595dc31)