### PR TITLE
Reduce top padding in main layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     max-width: 600px;
     margin: 0 auto;
-    padding: 24px 15px 20px;
+    padding: 16px 15px 20px;
     background: #fffbe6;
     min-height: 100vh;
     display: flex;
@@ -30,7 +30,7 @@ body {
     background: transparent;
     background-color: transparent;
     border-radius: 15px;
-    padding: 25px 20px;
+    padding: 16px 20px;
     box-shadow: none;
     border: none;
     text-align: center;


### PR DESCRIPTION
## Summary
- reduce body top padding to tighten spacing at the top of the page
- lower container padding so header sits closer to the viewport edge

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e465eafe08326bdd7d091d7ab2c70)